### PR TITLE
Add booking settings configuration and fake prepayment flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pnpm-debug.log*
 *.local
 *.swp
 *.swo
+
+# Prisma SQLite
+prisma/**/*.db

--- a/prisma/migrations/20251002133537_booking_settings/migration.sql
+++ b/prisma/migrations/20251002133537_booking_settings/migration.sql
@@ -1,0 +1,68 @@
+/*
+  Warnings:
+
+  - Made the column `phone` on table `Booking` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- CreateTable
+CREATE TABLE "BookingSettings" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT DEFAULT 1,
+    "enableDateTimeStep" BOOLEAN NOT NULL DEFAULT true,
+    "fixedDate" DATETIME,
+    "fixedTime" TEXT,
+    "enabledTypes" TEXT NOT NULL,
+    "typeLabels" TEXT NOT NULL,
+    "prepayTypes" TEXT NOT NULL,
+    "prepayAmountCents" INTEGER,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO "BookingSettings" (
+    "id",
+    "enableDateTimeStep",
+    "fixedDate",
+    "fixedTime",
+    "enabledTypes",
+    "typeLabels",
+    "prepayTypes",
+    "prepayAmountCents",
+    "createdAt",
+    "updatedAt"
+  )
+  VALUES (
+    1,
+    0,
+    '2025-12-20T00:00:00.000Z',
+    '19:00',
+    json('["pranzo","evento"]'),
+    json('{"pranzo":"Pranzo","evento":"Serata Speciale"}'),
+    json('["evento"]'),
+    1500,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  );
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Booking" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "date" DATETIME NOT NULL,
+    "people" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT NOT NULL,
+    "notes" TEXT,
+    "type" TEXT NOT NULL,
+    "agreePrivacy" BOOLEAN NOT NULL DEFAULT false,
+    "agreeMarketing" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "prepayToken" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_Booking" ("agreeMarketing", "agreePrivacy", "createdAt", "date", "email", "id", "name", "notes", "people", "phone", "type") SELECT "agreeMarketing", "agreePrivacy", "createdAt", "date", "email", "id", "name", "notes", "people", "phone", "type" FROM "Booking";
+DROP TABLE "Booking";
+ALTER TABLE "new_Booking" RENAME TO "Booking";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,24 +9,47 @@ datasource db {
 }
 
 model Booking {
-  id             Int       @id @default(autoincrement())
+  id             Int            @id @default(autoincrement())
   date           DateTime
   people         Int
   name           String
   email          String
-  phone          String?
+  phone          String
   notes          String?
 
   // 👇 aggiunte
   type           BookingType
-  agreePrivacy   Boolean   @default(false)
-  agreeMarketing Boolean   @default(false)
+  agreePrivacy   Boolean        @default(false)
+  agreeMarketing Boolean        @default(false)
+  status         BookingStatus  @default(pending)
+  prepayToken    String?
 
-  createdAt      DateTime  @default(now())
+  createdAt      DateTime       @default(now())
+}
+
+model BookingSettings {
+  id                  Int      @id @default(1)
+  enableDateTimeStep  Boolean  @default(true)
+  fixedDate           DateTime?
+  fixedTime           String?
+  enabledTypes        Json
+  typeLabels          Json
+  prepayTypes         Json
+  prepayAmountCents   Int?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 }
 
 enum BookingType {
   pranzo
   aperitivo
   evento
+}
+
+enum BookingStatus {
+  pending
+  pending_payment
+  confirmed
+  failed
+  expired
 }

--- a/src/app/api/booking-config/route.ts
+++ b/src/app/api/booking-config/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { DEFAULT_BOOKING_CONFIG_DTO, getBookingSettings, toBookingConfigDTO } from '@/lib/bookingSettings';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  console.log('[GET /api/booking-config] start');
+  try {
+    const settings = await getBookingSettings();
+    const dto = toBookingConfigDTO(settings);
+    console.log('[GET /api/booking-config] ok');
+    return NextResponse.json(dto);
+  } catch (error) {
+    console.error('[GET /api/booking-config] error', error);
+    return NextResponse.json(DEFAULT_BOOKING_CONFIG_DTO, { status: 200 });
+  }
+}

--- a/src/app/api/bookings/fake-cancel/route.ts
+++ b/src/app/api/bookings/fake-cancel/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  token: z.string().min(1, 'Token mancante'),
+});
+
+export async function POST(req: Request) {
+  console.log('[POST /api/bookings/fake-cancel] start');
+  try {
+    const json = await req.json();
+    const { token } = bodySchema.parse(json);
+
+    const booking = await prisma.booking.findFirst({
+      where: { prepayToken: token, status: 'pending_payment' },
+    });
+
+    if (!booking) {
+      console.warn('[POST /api/bookings/fake-cancel] token not found', token);
+      return NextResponse.json({ ok: false, error: 'Pagamento non trovato' }, { status: 404 });
+    }
+
+    await prisma.booking.update({
+      where: { id: booking.id },
+      data: { status: 'failed', prepayToken: null },
+    });
+
+    console.log('[POST /api/bookings/fake-cancel] ok', booking.id);
+    return NextResponse.json({ ok: true, bookingId: booking.id }, { status: 200 });
+  } catch (err: any) {
+    if (err?.name === 'ZodError') {
+      console.error('[POST /api/bookings/fake-cancel] ZodError:', err.flatten?.());
+      return NextResponse.json(
+        { ok: false, error: 'Dati non validi', details: err.flatten?.() },
+        { status: 400 }
+      );
+    }
+    console.error('[POST /api/bookings/fake-cancel] error:', err);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/bookings/fake-confirm/route.ts
+++ b/src/app/api/bookings/fake-confirm/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/prisma';
+import { sendBookingEmails } from '@/lib/mailer';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  token: z.string().min(1, 'Token mancante'),
+});
+
+export async function POST(req: Request) {
+  console.log('[POST /api/bookings/fake-confirm] start');
+  try {
+    const json = await req.json();
+    const { token } = bodySchema.parse(json);
+
+    const booking = await prisma.booking.findFirst({
+      where: { prepayToken: token, status: 'pending_payment' },
+    });
+
+    if (!booking) {
+      console.warn('[POST /api/bookings/fake-confirm] token not found', token);
+      return NextResponse.json({ ok: false, error: 'Pagamento non trovato' }, { status: 404 });
+    }
+
+    const updated = await prisma.booking.update({
+      where: { id: booking.id },
+      data: { status: 'confirmed', prepayToken: null },
+    });
+
+    try {
+      await sendBookingEmails({
+        id: updated.id,
+        date: updated.date.toISOString(),
+        people: updated.people,
+        name: updated.name,
+        email: updated.email,
+        phone: updated.phone,
+        notes: updated.notes ?? undefined,
+      });
+    } catch (mailErr) {
+      console.error('[POST /api/bookings/fake-confirm] Mailer error:', mailErr);
+      return NextResponse.json(
+        {
+          ok: true,
+          bookingId: updated.id,
+          warning: 'Prenotazione confermata ma invio email fallito. Controlla le credenziali SMTP.',
+        },
+        { status: 200 }
+      );
+    }
+
+    console.log('[POST /api/bookings/fake-confirm] ok', updated.id);
+    return NextResponse.json({ ok: true, bookingId: updated.id }, { status: 200 });
+  } catch (err: any) {
+    if (err?.name === 'ZodError') {
+      console.error('[POST /api/bookings/fake-confirm] ZodError:', err.flatten?.());
+      return NextResponse.json(
+        { ok: false, error: 'Dati non validi', details: err.flatten?.() },
+        { status: 400 }
+      );
+    }
+    console.error('[POST /api/bookings/fake-confirm] error:', err);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/bookings/prepay/route.ts
+++ b/src/app/api/bookings/prepay/route.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'crypto';
+import { NextResponse } from 'next/server';
+import { bookingSchema } from '@/components/booking/validation';
+import { prisma } from '@/lib/prisma';
+import { getBookingSettings, resolveBookingDate } from '@/lib/bookingSettings';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  console.log('[POST /api/bookings/prepay] start');
+  try {
+    const json = await req.json();
+    const parsed = bookingSchema.parse(json);
+
+    const settings = await getBookingSettings();
+
+    if (!settings.enabledTypes.includes(parsed.type)) {
+      console.warn('[POST /api/bookings/prepay] type not allowed', parsed.type);
+      return NextResponse.json(
+        { ok: false, error: 'Tipologia non disponibile' },
+        { status: 400 }
+      );
+    }
+
+    if (!settings.prepayTypes.includes(parsed.type)) {
+      return NextResponse.json(
+        { ok: false, error: 'Questa tipologia non richiede pagamento anticipato.' },
+        { status: 400 }
+      );
+    }
+
+    if (!settings.enableDateTimeStep && (!settings.fixedDate || !settings.fixedTime)) {
+      console.error('[POST /api/bookings/prepay] Fixed date/time misconfigured');
+      return NextResponse.json(
+        { ok: false, error: 'Configurazione prenotazioni non valida' },
+        { status: 500 }
+      );
+    }
+
+    const date = resolveBookingDate(settings, parsed.date, parsed.time);
+    const token = randomUUID();
+
+    const created = await prisma.booking.create({
+      data: {
+        date,
+        people: parsed.people,
+        type: parsed.type,
+        name: parsed.name,
+        email: parsed.email,
+        phone: parsed.phone,
+        notes: parsed.notes ?? null,
+        agreePrivacy: parsed.agreePrivacy,
+        agreeMarketing: parsed.agreeMarketing ?? false,
+        status: 'pending_payment',
+        prepayToken: token,
+      },
+    });
+
+    console.log('[POST /api/bookings/prepay] pending', created.id);
+    return NextResponse.json(
+      {
+        ok: true,
+        bookingId: created.id,
+        paymentUrl: `/fake-payment?token=${encodeURIComponent(token)}`,
+      },
+      { status: 201 }
+    );
+  } catch (err: any) {
+    if (err?.name === 'ZodError') {
+      console.error('[POST /api/bookings/prepay] ZodError:', err.flatten?.());
+      return NextResponse.json(
+        { ok: false, error: 'Dati non validi', details: err.flatten?.() },
+        { status: 400 }
+      );
+    }
+    console.error('[POST /api/bookings/prepay] error:', err);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/fake-payment/page.tsx
+++ b/src/app/fake-payment/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function FakePaymentPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token');
+
+  const [loading, setLoading] = useState<'confirm' | 'cancel' | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const disabled = useMemo(() => loading !== null, [loading]);
+
+  const callApi = useCallback(
+    async (action: 'fake-confirm' | 'fake-cancel') => {
+      if (!token) return;
+      setLoading(action === 'fake-confirm' ? 'confirm' : 'cancel');
+      setError(null);
+      setMessage(null);
+
+      try {
+        const res = await fetch(`/api/bookings/${action}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token }),
+        });
+
+        const body = await res.json().catch(() => ({}));
+
+        if (!res.ok || !body.ok) {
+          setError(body?.error || 'Operazione non riuscita.');
+          return;
+        }
+
+        if (action === 'fake-confirm') {
+          setMessage('Pagamento completato! Prenotazione confermata.');
+        } else {
+          setMessage('Pagamento annullato. Prenotazione annullata.');
+        }
+      } catch (err) {
+        console.error('[fake-payment] request error', err);
+        setError('Errore di rete. Riprova.');
+      } finally {
+        setLoading(null);
+      }
+    },
+    [token]
+  );
+
+  const goBack = useCallback(() => {
+    router.push('/prenota');
+  }, [router]);
+
+  if (!token) {
+    return (
+      <main style={{ padding: '2rem', textAlign: 'center' }}>
+        <h1>Pagamento simulato</h1>
+        <p>Token non fornito. Torna alla prenotazione.</p>
+        <button className="btn" onClick={goBack}>
+          Torna alla prenotazione
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: '2rem', maxWidth: '480px', margin: '0 auto' }}>
+      <h1>Pagamento simulato</h1>
+      <p>
+        Stai finalizzando il pagamento per la tua prenotazione. Questo flusso è solo una simulazione, non verrà
+        addebitato nulla.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1.5rem' }}>
+        <button className="btn" disabled={disabled} onClick={() => callApi('fake-confirm')}>
+          {loading === 'confirm' ? 'Completamento…' : 'Completa pagamento'}
+        </button>
+        <button
+          className="btn"
+          disabled={disabled}
+          onClick={() => callApi('fake-cancel')}
+          style={{ background: 'var(--color-border)' }}
+        >
+          {loading === 'cancel' ? 'Annullamento…' : 'Annulla pagamento'}
+        </button>
+      </div>
+
+      {message && <p style={{ marginTop: '1.5rem', color: 'var(--color-success, green)' }}>{message}</p>}
+      {error && <p style={{ marginTop: '1.5rem', color: 'var(--color-error, crimson)' }}>{error}</p>}
+
+      <p style={{ marginTop: '2rem' }}>
+        Token corrente: <code>{token}</code>
+      </p>
+      <button className="btn" style={{ marginTop: '1rem' }} onClick={goBack}>
+        Torna alla prenotazione
+      </button>
+    </main>
+  );
+}

--- a/src/components/booking/BookingWizard.tsx
+++ b/src/components/booking/BookingWizard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { bookingSchema } from './validation';
@@ -8,141 +8,266 @@ import Step1Date from './steps/Step1Date';
 import Step2People from './steps/Step2People';
 import Step3Details from './steps/Step3Details';
 import Step4Review from './steps/Step4Review';
+import type { BookingConfigDTO } from '@/types/bookingConfig';
 
-// -----------------------------
-// Tipi “da form” (semplici)
-// -----------------------------
 type BookingType = 'pranzo' | 'aperitivo' | 'evento';
-type Step = 1 | 2 | 3 | 4;
+type StepKey = 'dateTime' | 'peopleType' | 'details' | 'review';
 
 type FormValues = {
-  date: string;        // "YYYY-MM-DD"
-  time: string;        // "HH:mm"
+  date: string;
+  time: string;
   people: number;
   type: BookingType;
   name: string;
   email: string;
-  phone: string;       // obbligatorio
+  phone: string;
   notes?: string;
   agreePrivacy: boolean;
   agreeMarketing?: boolean;
 };
 
-// campi da validare per ogni step
-const STEP_FIELDS: Record<Step, (keyof FormValues)[]> = {
-  1: ['date', 'time'],
-  2: ['people', 'type'],
-  3: ['name', 'email', 'phone', 'notes'],
-  4: ['agreePrivacy'], // il check privacy è nello step finale
+const STEP_FIELDS: Record<StepKey, (keyof FormValues)[]> = {
+  dateTime: ['date', 'time'],
+  peopleType: ['people', 'type'],
+  details: ['name', 'email', 'phone', 'notes'],
+  review: ['agreePrivacy'],
 };
 
-// Progress bar
-const steps: Array<{ id: Step; label: string }> = [
-  { id: 1, label: 'Data & orario' },
-  { id: 2, label: 'Persone & tipologia' },
-  { id: 3, label: 'Dettagli' },
-  { id: 4, label: 'Riepilogo' },
+const BASE_STEPS: Array<{ key: StepKey; label: string }> = [
+  { key: 'dateTime', label: 'Data & orario' },
+  { key: 'peopleType', label: 'Persone & tipologia' },
+  { key: 'details', label: 'Dettagli' },
+  { key: 'review', label: 'Riepilogo' },
 ];
 
+const DEFAULT_FORM_VALUES: FormValues = {
+  date: '',
+  time: '',
+  people: 2,
+  type: 'pranzo',
+  name: '',
+  email: '',
+  phone: '',
+  notes: '',
+  agreePrivacy: false,
+  agreeMarketing: false,
+};
+
+function buildResetValues(config: BookingConfigDTO | null): FormValues {
+  const firstType = (config?.enabledTypes[0] as BookingType | undefined) ?? 'pranzo';
+  return {
+    ...DEFAULT_FORM_VALUES,
+    date: config?.enableDateTimeStep === false ? config.fixedDate ?? '' : '',
+    time: config?.enableDateTimeStep === false ? config.fixedTime ?? '' : '',
+    type: firstType,
+  };
+}
+
 export default function BookingWizard() {
-  const [step, setStep] = useState<Step>(1);
+  const [config, setConfig] = useState<BookingConfigDTO | null>(null);
+  const [loadingConfig, setLoadingConfig] = useState(true);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [stepIndex, setStepIndex] = useState(0);
 
   const methods = useForm<FormValues>({
     resolver: zodResolver(bookingSchema),
     mode: 'onChange',
-    shouldUnregister: false, // conserva i valori degli step precedenti
-    defaultValues: {
-      date: '',
-      time: '',
-      people: 2,
-      type: 'pranzo',
-      name: '',
-      email: '',
-      phone: '',
-      notes: '',
-      agreePrivacy: false,
-      agreeMarketing: false,
-    },
+    shouldUnregister: false,
+    defaultValues: DEFAULT_FORM_VALUES,
   });
 
+  useEffect(() => {
+    let active = true;
+    async function loadConfig() {
+      try {
+        const res = await fetch('/api/booking-config');
+        if (!res.ok) {
+          throw new Error(`Impostazioni non disponibili (${res.status})`);
+        }
+        const data = (await res.json()) as BookingConfigDTO;
+        if (active) {
+          setConfig(data);
+          setConfigError(null);
+        }
+      } catch (err: any) {
+        console.error('[BookingWizard] config error', err);
+        if (active) {
+          setConfigError('Impossibile caricare le impostazioni di prenotazione.');
+        }
+      } finally {
+        if (active) setLoadingConfig(false);
+      }
+    }
+    loadConfig();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!config) return;
+    const defaults = buildResetValues(config);
+    methods.reset(defaults);
+    setStepIndex(0);
+  }, [config, methods]);
+
+  useEffect(() => {
+    if (!config) return;
+    if (config.enableDateTimeStep) return;
+    if (config.fixedDate) {
+      methods.setValue('date', config.fixedDate, { shouldValidate: true });
+    }
+    if (config.fixedTime) {
+      methods.setValue('time', config.fixedTime, { shouldValidate: true });
+    }
+  }, [config, methods]);
+
+  const activeSteps = useMemo(() => {
+    if (!config) return BASE_STEPS;
+    return BASE_STEPS.filter(step => (config.enableDateTimeStep ? true : step.key !== 'dateTime'));
+  }, [config]);
+
+  useEffect(() => {
+    if (!config) return;
+    const allowed = config.enabledTypes as BookingType[];
+    if (allowed.length === 0) return;
+    const current = methods.getValues('type');
+    if (!allowed.includes(current)) {
+      methods.setValue('type', allowed[0], { shouldValidate: true });
+    }
+  }, [config, methods]);
+
+  const typeOptions = useMemo(
+    () =>
+      config
+        ? config.enabledTypes.map(value => ({
+            value,
+            label: config.typeLabels[value] ?? value,
+            requiresPrepay: config.prepayTypes.includes(value),
+          }))
+        : [],
+    [config]
+  );
+
+  const currentStep = activeSteps[stepIndex] ?? activeSteps[0];
+
   const next = async () => {
-    // ✅ valida solo i campi dello step corrente
-    const valid = await methods.trigger(STEP_FIELDS[step], { shouldFocus: true });
-    if (valid) setStep(prev => (Math.min(4, (prev + 1) as Step) as Step));
+    if (!currentStep) return;
+    const valid = await methods.trigger(STEP_FIELDS[currentStep.key], { shouldFocus: true });
+    if (valid && stepIndex < activeSteps.length - 1) {
+      setStepIndex(prev => prev + 1);
+    }
   };
 
-  const back = () => setStep(prev => (Math.max(1, (prev - 1) as Step) as Step));
+  const back = () => {
+    setStepIndex(prev => (prev > 0 ? prev - 1 : prev));
+  };
 
-  // Submit finale
   const onSubmit = async (data: FormValues) => {
+    if (!config) {
+      alert('Impostazioni non disponibili. Riprova più tardi.');
+      return;
+    }
+
     const payload = {
       ...data,
       phone: data.phone.trim(),
       notes: data.notes && data.notes.trim().length ? data.notes.trim() : undefined,
     };
 
+    const requiresPrepay = config.prepayTypes.includes(payload.type);
+    const endpoint = requiresPrepay ? '/api/bookings/prepay' : '/api/bookings';
+
     try {
-      const res = await fetch('/api/bookings', {
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
 
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        console.error('Booking error:', err);
-        alert('Errore nell’invio della prenotazione.\n' + (err?.error || res.status));
+      const body = await res.json().catch(() => ({}));
+
+      if (!res.ok || body?.ok === false) {
+        if (body?.requiresPrepay && body?.message) {
+          alert(body.message);
+          return;
+        }
+        alert('Errore nell’invio della prenotazione.\n' + (body?.error || res.status));
         return;
       }
 
-      const out = await res.json();
-      alert(`Richiesta inviata! Codice prenotazione #${out.bookingId}`);
-      methods.reset();
-      setStep(1);
-    } catch (e) {
-      console.error(e);
+      if (requiresPrepay) {
+        if (body.paymentUrl) {
+          window.location.href = body.paymentUrl as string;
+        } else {
+          alert('Prenotazione registrata ma link di pagamento non disponibile.');
+        }
+        return;
+      }
+
+      alert(`Richiesta inviata! Codice prenotazione #${body.bookingId}`);
+      methods.reset(buildResetValues(config));
+      setStepIndex(0);
+    } catch (error) {
+      console.error('[BookingWizard] submit error', error);
       alert('Errore di rete. Riprova più tardi.');
     }
   };
 
+  if (loadingConfig) {
+    return <p>Caricamento impostazioni…</p>;
+  }
+
+  if (configError) {
+    return <p>{configError}</p>;
+  }
+
+  if (!config) {
+    return <p>Impostazioni non disponibili.</p>;
+  }
+
+  if (config.enabledTypes.length === 0) {
+    return <p>Nessuna tipologia prenotabile al momento. Riprovare più tardi.</p>;
+  }
+
   return (
     <section aria-labelledby="booking-flow">
-      <h2 id="booking-flow" className="visually-hidden">Prenotazione</h2>
+      <h2 id="booking-flow" className="visually-hidden">
+        Prenotazione
+      </h2>
 
-      {/* Stepper */}
-      <ol
-        aria-label="Passaggi prenotazione"
-        style={{ display: 'flex', gap: '.5rem', listStyle: 'none', padding: 0 }}
-      >
-        {steps.map(s => (
+      <ol aria-label="Passaggi prenotazione" style={{ display: 'flex', gap: '.5rem', listStyle: 'none', padding: 0 }}>
+        {activeSteps.map((s, index) => (
           <li
-            key={s.id}
-            aria-current={step === s.id ? 'step' : undefined}
+            key={s.key}
+            aria-current={stepIndex === index ? 'step' : undefined}
             style={{
               padding: '.5rem .75rem',
               border: '1px solid var(--color-border)',
               borderRadius: '12px',
-              background: step === s.id ? 'var(--color-border)' : 'transparent',
+              background: stepIndex === index ? 'var(--color-border)' : 'transparent',
             }}
           >
-            {s.id}. {s.label}
+            {index + 1}. {s.label}
           </li>
         ))}
       </ol>
 
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(onSubmit)} aria-live="assertive">
-          {step === 1 && <Step1Date />}
-          {step === 2 && <Step2People />}
-          {step === 3 && <Step3Details />}
-          {step === 4 && <Step4Review />}
+          {currentStep?.key === 'dateTime' && <Step1Date />}
+          {currentStep?.key === 'peopleType' && (
+            <Step2People typeOptions={typeOptions} prepayAmountCents={config.prepayAmountCents} />
+          )}
+          {currentStep?.key === 'details' && <Step3Details />}
+          {currentStep?.key === 'review' && <Step4Review config={config} />}
 
           <div style={{ display: 'flex', gap: '.5rem', marginTop: '1rem' }}>
-            <button className="btn" type="button" onClick={back} disabled={step === 1}>
+            <button className="btn" type="button" onClick={back} disabled={stepIndex === 0}>
               Indietro
             </button>
 
-            {step < 4 ? (
+            {stepIndex < activeSteps.length - 1 ? (
               <button className="btn" type="button" onClick={next}>
                 Avanti
               </button>

--- a/src/components/booking/steps/Step2People.tsx
+++ b/src/components/booking/steps/Step2People.tsx
@@ -1,25 +1,86 @@
 'use client';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
-export default function Step2People() {
-  const { register, formState: { errors }, setValue, watch } = useFormContext();
+
+type Step2PeopleProps = {
+  typeOptions: Array<{ value: string; label: string; requiresPrepay?: boolean }>;
+  prepayAmountCents?: number;
+};
+
+export default function Step2People({ typeOptions, prepayAmountCents }: Step2PeopleProps) {
+  const {
+    register,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext();
+
   const people = watch('people');
+  const selectedType = watch('type');
+
+  useEffect(() => {
+    if (typeOptions.length === 0) return;
+    if (!typeOptions.some(option => option.value === selectedType)) {
+      const fallback = typeOptions[0];
+      setValue('type', fallback.value as any, { shouldValidate: true });
+    }
+  }, [selectedType, setValue, typeOptions]);
+
   return (
     <fieldset>
-      <legend>Persone & tipologia</legend>
-      <label htmlFor="people">Numero persone</label><br/>
-      <input id="people" type="number" min={1} max={50} {...register('people', { valueAsNumber:true })} aria-invalid={!!errors.people} aria-describedby="err-people" /><br/>
-      <span id="err-people" role="alert">{(errors.people as any)?.message}</span>
-      <div style={{ marginTop:'.75rem' }}>
-        <span id="type-label">Tipologia</span><br/>
-        <div role="radiogroup" aria-labelledby="type-label" style={{ display:'flex', gap:'.5rem' }}>
-          {['pranzo','aperitivo','evento'].map(t => (
-            <label key={t} style={{ border:'1px solid var(--color-border)', padding:'.5rem', borderRadius:'12px' }}>
-              <input type="radio" {...register('type')} value={t} onChange={()=>setValue('type', t as any)} /> {t}
-            </label>
-          ))}
+      <legend>Persone &amp; tipologia</legend>
+      <label htmlFor="people">Numero persone</label>
+      <br />
+      <input
+        id="people"
+        type="number"
+        min={1}
+        max={50}
+        {...register('people', { valueAsNumber: true })}
+        aria-invalid={!!errors.people}
+        aria-describedby="err-people"
+      />
+      <br />
+      <span id="err-people" role="alert">
+        {(errors.people as any)?.message}
+      </span>
+      <div style={{ marginTop: '.75rem' }}>
+        <span id="type-label">Tipologia</span>
+        <br />
+        <div role="radiogroup" aria-labelledby="type-label" style={{ display: 'flex', gap: '.5rem', flexWrap: 'wrap' }}>
+          {typeOptions.length === 0 ? (
+            <p>Nessuna tipologia disponibile al momento.</p>
+          ) : (
+            typeOptions.map(option => {
+              const requiresPrepay = option.requiresPrepay;
+              const prepayLabel =
+                requiresPrepay && prepayAmountCents
+                  ? ` (anticipo € ${(prepayAmountCents / 100).toFixed(2)})`
+                  : requiresPrepay
+                    ? ' (richiede anticipo)' 
+                    : '';
+              return (
+                <label
+                  key={option.value}
+                  style={{
+                    border: '1px solid var(--color-border)',
+                    padding: '.5rem',
+                    borderRadius: '12px',
+                    minWidth: '140px',
+                  }}
+                >
+                  <input type="radio" {...register('type')} value={option.value} />{' '}
+                  {option.label}
+                  {prepayLabel}
+                </label>
+              );
+            })
+          )}
         </div>
       </div>
-      <p style={{ marginTop:'.5rem' }}>Hai selezionato {people} {people===1?'persona':'persone'}.</p>
+      <p style={{ marginTop: '.5rem' }}>
+        Hai selezionato {people} {people === 1 ? 'persona' : 'persone'}.
+      </p>
     </fieldset>
   );
 }

--- a/src/components/booking/steps/Step4Review.tsx
+++ b/src/components/booking/steps/Step4Review.tsx
@@ -1,23 +1,66 @@
 'use client';
+
 import { useFormContext } from 'react-hook-form';
-export default function Step4Review() {
-  const { getValues, register, formState: { errors } } = useFormContext();
-  const v = getValues();
+import type { BookingConfigDTO } from '@/types/bookingConfig';
+
+type Step4ReviewProps = {
+  config: BookingConfigDTO;
+};
+
+export default function Step4Review({ config }: Step4ReviewProps) {
+  const {
+    getValues,
+    register,
+    formState: { errors },
+  } = useFormContext();
+
+  const values = getValues();
+  const typeLabel = config.typeLabels[values.type] ?? values.type;
+  const requiresPrepay = config.prepayTypes.includes(values.type);
+
   return (
     <section>
       <h3>Riepilogo</h3>
       <ul>
-        <li>Data: <strong>{v.date}</strong></li>
-        <li>Orario: <strong>{v.time}</strong></li>
-        <li>Persone: <strong>{v.people}</strong></li>
-        <li>Tipo: <strong>{v.type}</strong></li>
-        <li>Nome: <strong>{v.name}</strong></li>
-        <li>Email: <strong>{v.email}</strong></li>
-        <li>Telefono: <strong>{v.phone}</strong></li>
+        <li>
+          Data: <strong>{values.date}</strong>
+        </li>
+        <li>
+          Orario: <strong>{values.time}</strong>
+        </li>
+        <li>
+          Persone: <strong>{values.people}</strong>
+        </li>
+        <li>
+          Tipo: <strong>{typeLabel}</strong>
+        </li>
+        <li>
+          Nome: <strong>{values.name}</strong>
+        </li>
+        <li>
+          Email: <strong>{values.email}</strong>
+        </li>
+        <li>
+          Telefono: <strong>{values.phone}</strong>
+        </li>
       </ul>
+      {requiresPrepay && (
+        <p style={{ marginTop: '1rem', color: 'var(--color-warning, #a15f00)' }}>
+          Questa tipologia richiede il pagamento anticipato per completare la prenotazione.
+        </p>
+      )}
       <div>
-        <input id="agreePrivacy" type="checkbox" {...register('agreePrivacy')} aria-invalid={!!errors.agreePrivacy} aria-describedby="err-privacy" />
-        <label htmlFor="agreePrivacy">Ho letto e accetto la <a href="/privacy">Privacy</a>.</label><br/>
+        <input
+          id="agreePrivacy"
+          type="checkbox"
+          {...register('agreePrivacy')}
+          aria-invalid={!!errors.agreePrivacy}
+          aria-describedby="err-privacy"
+        />
+        <label htmlFor="agreePrivacy">
+          Ho letto e accetto la <a href="/privacy">Privacy</a>.
+        </label>
+        <br />
         <span id="err-privacy" role="alert">{(errors.agreePrivacy as any)?.message}</span>
       </div>
       <div>

--- a/src/lib/bookingSettings.ts
+++ b/src/lib/bookingSettings.ts
@@ -1,0 +1,98 @@
+import type { BookingType } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
+import { prisma } from './prisma';
+import type { BookingConfigDTO } from '@/types/bookingConfig';
+
+export type NormalizedBookingSettings = {
+  enableDateTimeStep: boolean;
+  fixedDate?: Date;
+  fixedTime?: string;
+  enabledTypes: BookingType[];
+  typeLabels: Record<string, string>;
+  prepayTypes: BookingType[];
+  prepayAmountCents?: number;
+};
+
+const DEFAULT_BOOKING_SETTINGS: NormalizedBookingSettings = {
+  enableDateTimeStep: false,
+  fixedDate: new Date('2025-12-20T00:00:00.000Z'),
+  fixedTime: '19:00',
+  enabledTypes: ['pranzo', 'evento'],
+  typeLabels: { pranzo: 'Pranzo', evento: 'Serata Speciale' },
+  prepayTypes: ['evento'],
+  prepayAmountCents: 1500,
+};
+
+function asStringArray(value: Prisma.JsonValue | null | undefined, fallback: BookingType[]): BookingType[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is BookingType => typeof item === 'string') as BookingType[];
+  }
+  return fallback;
+}
+
+function asRecord(value: Prisma.JsonValue | null | undefined, fallback: Record<string, string>) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const entries = Object.entries(value).filter(([, v]) => typeof v === 'string');
+    return Object.fromEntries(entries) as Record<string, string>;
+  }
+  return fallback;
+}
+
+export async function getBookingSettings(): Promise<NormalizedBookingSettings> {
+  const row = await prisma.bookingSettings.findUnique({ where: { id: 1 } });
+
+  if (!row) {
+    return { ...DEFAULT_BOOKING_SETTINGS };
+  }
+
+  const enabledTypes = asStringArray(row.enabledTypes as Prisma.JsonValue, DEFAULT_BOOKING_SETTINGS.enabledTypes);
+  const typeLabels = asRecord(row.typeLabels as Prisma.JsonValue, DEFAULT_BOOKING_SETTINGS.typeLabels);
+  const prepayTypes = asStringArray(row.prepayTypes as Prisma.JsonValue, DEFAULT_BOOKING_SETTINGS.prepayTypes);
+
+  return {
+    enableDateTimeStep: row.enableDateTimeStep,
+    fixedDate: row.fixedDate ?? DEFAULT_BOOKING_SETTINGS.fixedDate,
+    fixedTime: row.fixedTime ?? DEFAULT_BOOKING_SETTINGS.fixedTime,
+    enabledTypes: [...enabledTypes],
+    typeLabels: { ...typeLabels },
+    prepayTypes: [...prepayTypes],
+    prepayAmountCents: row.prepayAmountCents ?? DEFAULT_BOOKING_SETTINGS.prepayAmountCents,
+  };
+}
+
+export function toBookingConfigDTO(settings: NormalizedBookingSettings): BookingConfigDTO {
+  const fixedDate = settings.fixedDate?.toISOString().slice(0, 10);
+  return {
+    enableDateTimeStep: settings.enableDateTimeStep,
+    ...(fixedDate ? { fixedDate } : {}),
+    ...(settings.fixedTime ? { fixedTime: settings.fixedTime } : {}),
+    enabledTypes: settings.enabledTypes,
+    typeLabels: settings.typeLabels,
+    prepayTypes: settings.prepayTypes,
+    ...(settings.prepayAmountCents != null ? { prepayAmountCents: settings.prepayAmountCents } : {}),
+  };
+}
+
+export function resolveBookingDate(
+  settings: NormalizedBookingSettings,
+  requestedDate: string,
+  requestedTime: string,
+): Date {
+  const targetDate = settings.enableDateTimeStep
+    ? requestedDate
+    : settings.fixedDate?.toISOString().slice(0, 10) ?? requestedDate;
+  const targetTime = settings.enableDateTimeStep ? requestedTime : settings.fixedTime ?? requestedTime;
+
+  const iso = `${targetDate}T${targetTime}:00`;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid date/time configuration');
+  }
+  return date;
+}
+
+export function typeRequiresPrepay(settings: NormalizedBookingSettings, type: string): boolean {
+  return settings.prepayTypes.includes(type as BookingType);
+}
+
+export const DEFAULT_BOOKING_CONFIG_DTO: BookingConfigDTO = toBookingConfigDTO(DEFAULT_BOOKING_SETTINGS);

--- a/src/types/bookingConfig.ts
+++ b/src/types/bookingConfig.ts
@@ -1,0 +1,9 @@
+export type BookingConfigDTO = {
+  enableDateTimeStep: boolean;
+  fixedDate?: string;
+  fixedTime?: string;
+  enabledTypes: string[];
+  typeLabels: Record<string, string>;
+  prepayTypes: string[];
+  prepayAmountCents?: number;
+};


### PR DESCRIPTION
## Summary
- add booking settings model/migration and default seed row for backend-driven booking configuration
- expose a booking-config API and extend booking/prepay endpoints with prepayment handling and fake confirm/cancel routes
- update the booking wizard to load config-driven steps/options and add a fake payment page for testing the prepay flow

## Testing
- pnpm type-check

------
https://chatgpt.com/codex/tasks/task_e_68de7ef40ab483228e0f8e5d92d1df0e