### PR TITLE
feat: add cart REST endpoints

### DIFF
--- a/src/app/api/cart/[id]/items/route.ts
+++ b/src/app/api/cart/[id]/items/route.ts
@@ -1,0 +1,204 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getCartByToken, recalcCartTotal, toCartDTO } from '@/lib/cart';
+import { prisma } from '@/lib/prisma';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const addItemSchema = z
+  .object({
+    productId: z.number().int().positive(),
+    qty: z.number().int().positive(),
+    meta: z.unknown().optional(),
+  })
+  .strict();
+
+const updateItemSchema = z
+  .object({
+    itemId: z.number().int().positive(),
+    qty: z.number().int(),
+  })
+  .strict();
+
+async function ensureCartExists(cartId: string) {
+  const cart = await prisma.cart.findUnique({ where: { id: cartId } });
+  return cart;
+}
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = addItemSchema.safeParse(body ?? {});
+
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const cartId = params.id;
+    const cart = await ensureCartExists(cartId);
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    const { productId, qty, meta } = parsed.data;
+
+    const product = await prisma.product.findUnique({ where: { id: productId } });
+
+    if (!product) {
+      return NextResponse.json({ ok: false, error: 'Product not found' }, { status: 404 });
+    }
+
+    // TODO: handle stock/availability validation when implementing inventory
+
+    const existingItem = await prisma.cartItem.findFirst({
+      where: {
+        cartId,
+        productId,
+      },
+    });
+
+    if (existingItem) {
+      await prisma.cartItem.update({
+        where: { id: existingItem.id },
+        data: {
+          qty: existingItem.qty + qty,
+          nameSnapshot: product.name,
+          priceCentsSnapshot: product.priceCents,
+          imageUrlSnapshot: product.imageUrl ?? null,
+          meta: meta ?? existingItem.meta ?? null,
+        },
+      });
+    } else {
+      await prisma.cartItem.create({
+        data: {
+          cartId,
+          productId,
+          qty,
+          nameSnapshot: product.name,
+          priceCentsSnapshot: product.priceCents,
+          imageUrlSnapshot: product.imageUrl ?? null,
+          meta: meta ?? null,
+        },
+      });
+    }
+
+    await recalcCartTotal(cartId);
+
+    const updatedCart = await getCartByToken(cartId);
+
+    if (!updatedCart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(updatedCart) });
+  } catch (error) {
+    console.error(`[POST /api/cart/${params.id}/items] error`, error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = updateItemSchema.safeParse(body ?? {});
+
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const cartId = params.id;
+    const cart = await ensureCartExists(cartId);
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    const { itemId, qty } = parsed.data;
+
+    const item = await prisma.cartItem.findFirst({
+      where: {
+        id: itemId,
+        cartId,
+      },
+    });
+
+    if (!item) {
+      return NextResponse.json({ ok: false, error: 'Item not found' }, { status: 404 });
+    }
+
+    if (qty <= 0) {
+      await prisma.cartItem.delete({ where: { id: item.id } });
+    } else {
+      await prisma.cartItem.update({
+        where: { id: item.id },
+        data: { qty },
+      });
+    }
+
+    await recalcCartTotal(cartId);
+
+    const updatedCart = await getCartByToken(cartId);
+
+    if (!updatedCart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(updatedCart) });
+  } catch (error) {
+    console.error(`[PATCH /api/cart/${params.id}/items] error`, error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const url = new URL(request.url);
+    const itemIdParam = url.searchParams.get('itemId');
+
+    if (!itemIdParam) {
+      return NextResponse.json({ ok: false, error: 'Missing itemId' }, { status: 400 });
+    }
+
+    const itemId = Number(itemIdParam);
+
+    if (!Number.isInteger(itemId) || itemId <= 0) {
+      return NextResponse.json({ ok: false, error: 'Invalid itemId' }, { status: 400 });
+    }
+
+    const cartId = params.id;
+    const cart = await ensureCartExists(cartId);
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    const item = await prisma.cartItem.findFirst({
+      where: {
+        id: itemId,
+        cartId,
+      },
+    });
+
+    if (!item) {
+      return NextResponse.json({ ok: false, error: 'Item not found' }, { status: 404 });
+    }
+
+    await prisma.cartItem.delete({ where: { id: item.id } });
+
+    await recalcCartTotal(cartId);
+
+    const updatedCart = await getCartByToken(cartId);
+
+    if (!updatedCart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(updatedCart) });
+  } catch (error) {
+    console.error(`[DELETE /api/cart/${params.id}/items] error`, error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/cart/[id]/route.ts
+++ b/src/app/api/cart/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getCartByToken, toCartDTO } from '@/lib/cart';
+import { prisma } from '@/lib/prisma';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const updateCartSchema = z
+  .object({
+    status: z.enum(['open', 'locked', 'expired']).optional(),
+  })
+  .strict();
+
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  try {
+    const cart = await getCartByToken(params.id);
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(cart) });
+  } catch (error) {
+    console.error(`[GET /api/cart/${params.id}] error`, error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = updateCartSchema.safeParse(body ?? {});
+
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const { status } = parsed.data;
+
+    if (!status) {
+      return NextResponse.json({ ok: false, error: 'Nothing to update' }, { status: 400 });
+    }
+
+    const cart = await prisma.cart.update({
+      where: { id: params.id },
+      data: { status },
+    });
+
+    const cartWithItems = await getCartByToken(cart.id);
+
+    if (!cartWithItems) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(cartWithItems) });
+  } catch (error) {
+    console.error(`[PATCH /api/cart/${params.id}] error`, error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { ensureCart, getCartByToken, toCartDTO } from '@/lib/cart';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const postSchema = z
+  .object({
+    token: z.string().min(1).optional(),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = postSchema.safeParse(body ?? {});
+
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const { token } = parsed.data;
+
+    let cart = token ? await getCartByToken(token) : null;
+
+    if (!cart) {
+      const ensured = await ensureCart({ token });
+      cart = await getCartByToken(ensured.id);
+    }
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Unable to create cart' }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(cart) });
+  } catch (error) {
+    console.error('[POST /api/cart] error', error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const token = url.searchParams.get('token');
+
+    if (!token) {
+      return NextResponse.json({ ok: false, error: 'Missing cart token' }, { status: 400 });
+    }
+
+    const cart = await getCartByToken(token);
+
+    if (!cart) {
+      return NextResponse.json({ ok: false, error: 'Cart not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ ok: true, data: toCartDTO(cart) });
+  } catch (error) {
+    console.error('[GET /api/cart] error', error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,0 +1,71 @@
+import type { Cart, CartItem } from '@prisma/client';
+
+import { prisma } from './prisma';
+
+import type { CartDTO, CartItemDTO } from '@/types/cart';
+
+type CartWithItems = Cart & { items: CartItem[] };
+
+type EnsureCartParams = {
+  token?: string | null;
+};
+
+export async function ensureCart({ token }: EnsureCartParams = {}): Promise<Cart> {
+  if (token) {
+    const existing = await prisma.cart.findUnique({ where: { id: token } });
+    if (existing) return existing;
+  }
+
+  const cart = await prisma.cart.create({
+    data: {
+      status: 'open',
+      totalCents: 0,
+    },
+  });
+
+  return cart;
+}
+
+export async function getCartByToken(token: string): Promise<CartWithItems | null> {
+  if (!token) return null;
+
+  const cart = await prisma.cart.findUnique({
+    where: { id: token },
+    include: { items: true },
+  });
+
+  return cart;
+}
+
+export async function recalcCartTotal(cartId: string): Promise<number> {
+  const items = await prisma.cartItem.findMany({
+    where: { cartId },
+  });
+
+  const total = items.reduce((sum, item) => sum + item.qty * item.priceCentsSnapshot, 0);
+
+  await prisma.cart.update({
+    where: { id: cartId },
+    data: { totalCents: total },
+  });
+
+  return total;
+}
+
+export function toCartDTO(cart: CartWithItems): CartDTO {
+  return {
+    id: cart.id,
+    token: cart.id,
+    status: cart.status as CartDTO['status'],
+    totalCents: cart.totalCents,
+    items: cart.items.map((item): CartItemDTO => ({
+      id: item.id,
+      productId: item.productId,
+      nameSnapshot: item.nameSnapshot,
+      priceCentsSnapshot: item.priceCentsSnapshot,
+      qty: item.qty,
+      imageUrlSnapshot: item.imageUrlSnapshot ?? undefined,
+      meta: item.meta ?? undefined,
+    })),
+  };
+}

--- a/src/types/cart.ts
+++ b/src/types/cart.ts
@@ -1,0 +1,28 @@
+export type CartItemDTO = {
+  id: number;
+  productId: number;
+  nameSnapshot: string;
+  priceCentsSnapshot: number;
+  qty: number;
+  imageUrlSnapshot?: string;
+  meta?: unknown;
+};
+
+export type CartDTO = {
+  id: string;
+  token: string;
+  status: 'open' | 'locked' | 'expired';
+  totalCents: number;
+  items: CartItemDTO[];
+};
+
+export type AddItemInput = {
+  productId: number;
+  qty: number;
+  meta?: unknown;
+};
+
+export type UpdateItemInput = {
+  itemId: number;
+  qty: number;
+};


### PR DESCRIPTION
## Summary
- add cart DTOs and helper utilities for ensuring carts, fetching by token, recalculating totals, and mapping to API payloads
- expose REST endpoints for creating/fetching carts by token and fetching/updating carts by id
- add REST endpoints for cart item CRUD operations that snapshot product data and keep totals in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c3bac5cc8322a845aad7397fe592