### PR TITLE
Add order checkout endpoint with zero total auto confirmation

### DIFF
--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { createOrderFromCart, OrderCheckoutError, toOrderDTO } from '@/lib/orders';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const checkoutSchema = z
+  .object({
+    token: z.string().min(1),
+    email: z.string().email(),
+    name: z.string().min(1),
+    phone: z.string().min(1).optional(),
+    notes: z.string().min(1).max(2000).optional(),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = checkoutSchema.safeParse(body ?? {});
+
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Invalid payload' }, { status: 400 });
+    }
+
+    try {
+      const order = await createOrderFromCart(parsed.data);
+      const dto = toOrderDTO(order);
+
+      return NextResponse.json({ ok: true, data: dto });
+    } catch (error) {
+      if (error instanceof OrderCheckoutError) {
+        return NextResponse.json({ ok: false, error: error.message }, { status: error.status });
+      }
+
+      console.error('[POST /api/orders] order error', error);
+      return NextResponse.json({ ok: false, error: 'Unable to create order' }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('[POST /api/orders] error', error);
+    return NextResponse.json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,0 +1,90 @@
+import type { Cart, CartItem, Order } from '@prisma/client';
+
+import { prisma } from './prisma';
+import { getCartByToken, recalcCartTotal } from './cart';
+
+import type { CheckoutInput, OrderDTO } from '@/types/order';
+
+export type ValidateCartResult = {
+  ok: boolean;
+  reason?: string;
+};
+
+type CartWithItems = (Cart & { items: CartItem[] }) | null;
+
+export function validateCartReady(cart: CartWithItems): ValidateCartResult {
+  if (!cart) {
+    return { ok: false, reason: 'CART_NOT_FOUND' };
+  }
+
+  if (cart.status === 'expired') {
+    return { ok: false, reason: 'CART_EXPIRED' };
+  }
+
+  if (cart.status !== 'open' && cart.status !== 'locked') {
+    return { ok: false, reason: 'CART_NOT_READY' };
+  }
+
+  if (!Array.isArray(cart.items) || cart.items.length === 0) {
+    return { ok: false, reason: 'CART_EMPTY' };
+  }
+
+  return { ok: true };
+}
+
+export class OrderCheckoutError extends Error {
+  status: number;
+
+  constructor(code: string, status = 400) {
+    super(code);
+    this.name = 'OrderCheckoutError';
+    this.status = status;
+  }
+}
+
+export async function createOrderFromCart(input: CheckoutInput): Promise<Order> {
+  const { token, email, name, phone } = input;
+
+  if (!token) {
+    throw new OrderCheckoutError('MISSING_CART_TOKEN');
+  }
+
+  const cart = await getCartByToken(token);
+
+  const validation = validateCartReady(cart);
+  if (!validation.ok) {
+    throw new OrderCheckoutError(validation.reason ?? 'CART_NOT_READY');
+  }
+
+  const ensuredCart = cart!;
+
+  const totalCents = await recalcCartTotal(ensuredCart.id);
+  const status = totalCents === 0 ? 'confirmed' : 'pending';
+  const paymentRef = totalCents === 0 ? 'FREE' : null;
+
+  const order = await prisma.order.create({
+    data: {
+      cartId: ensuredCart.id,
+      email,
+      name,
+      phone: phone ?? null,
+      status,
+      totalCents,
+      ...(paymentRef ? { paymentRef } : {}),
+    },
+  });
+
+  return order;
+}
+
+export function toOrderDTO(order: Order): OrderDTO {
+  return {
+    id: order.id,
+    cartId: order.cartId,
+    status: order.status,
+    totalCents: order.totalCents,
+    discountCents: order.discountCents ?? undefined,
+    paymentRef: order.paymentRef ?? undefined,
+    createdAt: order.createdAt.toISOString(),
+  };
+}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,0 +1,17 @@
+export type OrderDTO = {
+  id: string;
+  cartId: string;
+  status: string;
+  totalCents: number;
+  discountCents?: number;
+  paymentRef?: string;
+  createdAt: string;
+};
+
+export type CheckoutInput = {
+  token: string;
+  email: string;
+  name: string;
+  phone?: string;
+  notes?: string;
+};


### PR DESCRIPTION
## Summary
- add shared order DTO and checkout input types
- implement order creation helpers that validate carts and confirm free checkouts
- expose a POST /api/orders endpoint that creates orders from carts

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c7b59ae883228ce8e1e66ae7a7bd