### PR TITLE
Address booking wizard lint warnings

### DIFF
--- a/src/app/(site)/layout.tsx
+++ b/src/app/(site)/layout.tsx
@@ -1,5 +1,6 @@
 // src/app/(site)/layout.tsx
 import type { ReactNode } from 'react';
+
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import CookieBar from '@/components/cookies/CookieBar';

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 // src/app/admin/page.tsx
 import type { CSSProperties } from 'react';
 import type { BookingStatus } from '@prisma/client';
+
 import { prisma } from '@/lib/prisma';
 import { toAdminBookingDTO } from '@/lib/admin/booking-dto';
 

--- a/src/app/admin/signin/page.tsx
+++ b/src/app/admin/signin/page.tsx
@@ -1,5 +1,6 @@
 // src/app/admin/signin/page.tsx
 import type { Metadata } from 'next';
+
 import EmailSignInForm from '@/components/admin/EmailSignInForm';
 
 type PageProps = {

--- a/src/app/api/admin/bookings/route.ts
+++ b/src/app/api/admin/bookings/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/admin/bookings/route.ts
 import { NextResponse } from 'next/server';
+
 import { prisma } from '@/lib/prisma';
 import { assertAdmin } from '@/lib/admin/session';
 import { toAdminBookingDTO } from '@/lib/admin/booking-dto';

--- a/src/app/api/admin/products/route.ts
+++ b/src/app/api/admin/products/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import type { Prisma } from '@prisma/client';
+
 import { prisma } from '@/lib/prisma';
 import { assertAdmin } from '@/lib/admin/session';
 

--- a/src/app/api/booking-config/route.ts
+++ b/src/app/api/booking-config/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+
 import {
   DEFAULT_BOOKING_CONFIG_DTO,
   getBookingSettings,
@@ -11,7 +12,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  console.log('[GET /api/booking-config] start');
   try {
     const settings = await getBookingSettings();
 
@@ -60,7 +60,6 @@ export async function GET() {
     };
 
     const dto = { ...toBookingConfigDTO(settings, menu), tiers };
-    console.log('[GET /api/booking-config] ok');
     return NextResponse.json(dto);
   } catch (error) {
     console.error('[GET /api/booking-config] error', error);

--- a/src/app/api/bookings/fake-cancel/route.ts
+++ b/src/app/api/bookings/fake-cancel/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+
 import { prisma } from '@/lib/prisma';
 
 export const runtime = 'nodejs';
@@ -10,7 +11,6 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: Request) {
-  console.log('[POST /api/bookings/fake-cancel] start');
   try {
     const json = await req.json();
     const { token } = bodySchema.parse(json);
@@ -29,7 +29,6 @@ export async function POST(req: Request) {
       data: { status: 'failed', prepayToken: null },
     });
 
-    console.log('[POST /api/bookings/fake-cancel] ok', booking.id);
     return NextResponse.json({ ok: true, bookingId: booking.id }, { status: 200 });
   } catch (err: any) {
     if (err?.name === 'ZodError') {

--- a/src/app/api/bookings/fake-confirm/route.ts
+++ b/src/app/api/bookings/fake-confirm/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+
 import { prisma } from '@/lib/prisma';
 import { sendBookingEmails } from '@/lib/mailer';
 import { normalizeStoredLunchItems, normalizeStoredDinnerItems } from '@/lib/lunchOrder';
@@ -12,7 +13,6 @@ const bodySchema = z.object({
 });
 
 export async function POST(req: Request) {
-  console.log('[POST /api/bookings/fake-confirm] start');
   try {
     const json = await req.json();
     const { token } = bodySchema.parse(json);
@@ -80,7 +80,6 @@ export async function POST(req: Request) {
       );
     }
 
-    console.log('[POST /api/bookings/fake-confirm] ok', updated.id);
     return NextResponse.json({ ok: true, bookingId: updated.id }, { status: 200 });
   } catch (err: any) {
     if (err?.name === 'ZodError') {

--- a/src/app/api/bookings/prepay/route.ts
+++ b/src/app/api/bookings/prepay/route.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
+
 import { NextResponse } from 'next/server';
+
 import { bookingSchema } from '@/components/booking/validation';
 import { prisma } from '@/lib/prisma';
 import { getBookingSettings, resolveBookingDate, typeRequiresPrepay } from '@/lib/bookingSettings';
@@ -9,7 +11,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-  console.log('[POST /api/bookings/prepay] start');
   try {
     const json = await req.json();
     const parsed = bookingSchema.parse(json);
@@ -144,7 +145,6 @@ export async function POST(req: Request) {
       },
     });
 
-    console.log('[POST /api/bookings/prepay] pending', created.id);
     return NextResponse.json(
       {
         ok: true,

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,5 +1,6 @@
 // src/app/api/bookings/route.ts
 import { NextResponse } from 'next/server';
+
 import { prisma } from '@/lib/prisma';
 import { sendBookingEmails } from '@/lib/mailer';
 import { bookingSchema } from '@/components/booking/validation';
@@ -11,7 +12,6 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {
-  console.log('[POST /api/bookings] start');
   try {
     const json = await req.json();
     const parsed = bookingSchema.parse(json);
@@ -188,7 +188,6 @@ export async function POST(req: Request) {
       );
     }
 
-    console.log('[POST /api/bookings] ok', created.id);
     return NextResponse.json({ ok: true, bookingId: created.id }, { status: 201 });
   } catch (err: any) {
     if (err?.name === 'ZodError') {

--- a/src/components/admin/catalog/ProductForm.tsx
+++ b/src/components/admin/catalog/ProductForm.tsx
@@ -576,7 +576,6 @@ const INITIAL_FILTERS: FilterState = { q: '', active: 'all', category: '' };
 function AdminCatalogProductsManager() {
   const toast = useToast();
   const [products, setProducts] = useState<AdminProduct[]>([]);
-  const [filters, setFilters] = useState<FilterState>(INITIAL_FILTERS);
   const filtersRef = useRef<FilterState>(INITIAL_FILTERS);
   const [searchDraft, setSearchDraft] = useState('');
   const [categoryDraft, setCategoryDraft] = useState('');
@@ -616,7 +615,6 @@ function AdminCatalogProductsManager() {
           category: targetFilters.category,
           active: targetFilters.active,
         };
-        setFilters(appliedFilters);
         filtersRef.current = appliedFilters;
         setSearchDraft(appliedFilters.q);
         setCategoryDraft(appliedFilters.category);

--- a/src/components/admin/catalog/SectionsPageClient.tsx
+++ b/src/components/admin/catalog/SectionsPageClient.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useToast } from '@/components/admin/ui/toast';
 import type { CSSProperties } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+
+import { useToast } from '@/components/admin/ui/toast';
 
 type SectionProductRow = {
   productId: number;

--- a/src/components/admin/menu/MenuDishesManager.tsx
+++ b/src/components/admin/menu/MenuDishesManager.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
+
 import { ToastProvider, useToast } from '@/components/admin/ui/toast';
 
 export type AdminMenuDish = {

--- a/src/components/booking/BookingWizard.tsx
+++ b/src/components/booking/BookingWizard.tsx
@@ -3,11 +3,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+
 import { bookingSchema } from './validation';
 import Step1Date from './steps/Step1Date';
 import Step2People from './steps/Step2People';
 import Step3Details from './steps/Step3Details';
 import Step4Review from './steps/Step4Review';
+
 import type { BookingConfigDTO } from '@/types/bookingConfig';
 
 type BookingType = 'pranzo' | 'cena' | 'aperitivo' | 'evento';

--- a/src/components/booking/steps/Step2People.tsx
+++ b/src/components/booking/steps/Step2People.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
+
 import type { BookingMenuDTO, BookingTiersDTO, BookingTierDTO } from '@/types/bookingConfig';
 
 type Step2PeopleProps = {
@@ -59,7 +60,8 @@ export default function Step2People({ typeOptions, prepayAmountCents, menu, tier
 
   const people = watch('people') as number;
   const selectedType = watch('type') as string;
-  const lunchOrder = (watch('lunchOrder') as LunchOrderItem[] | undefined) ?? [];
+  const lunchOrderValue = watch('lunchOrder') as LunchOrderItem[] | undefined;
+  const lunchOrder = useMemo(() => lunchOrderValue ?? [], [lunchOrderValue]);
   const selectedTier = watch('tier') as TierValue | undefined;
 
   useEffect(() => {
@@ -128,7 +130,7 @@ export default function Step2People({ typeOptions, prepayAmountCents, menu, tier
       setValue('tierLabel', selectedTier.label, { shouldValidate: true });
       setValue('tierPriceCents', selectedTier.priceCents, { shouldValidate: true });
     }
-  }, [isTierType, tierOptions, selectedTier, setValue]);
+  }, [isTierType, selectedType, tierOptions, selectedTier, setValue]);
 
   const filteredDishes = useMemo(() => {
     if (isLunch) {

--- a/src/components/booking/steps/Step4Review.tsx
+++ b/src/components/booking/steps/Step4Review.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useFormContext } from 'react-hook-form';
+
 import type { BookingConfigDTO } from '@/types/bookingConfig';
 
 type Step4ReviewProps = {

--- a/src/components/cookies/ConsentDebug.tsx
+++ b/src/components/cookies/ConsentDebug.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+
 import { useConsentStore } from '@/state/useConsentStore';
 
 export default function ConsentDebug() {

--- a/src/components/cookies/CookieBar.tsx
+++ b/src/components/cookies/CookieBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+
 import { useConsentStore } from '@/state/useConsentStore';
 
 const POLICY = process.env.NEXT_PUBLIC_POLICY_VERSION || '1.0.0';

--- a/src/components/cookies/PreferencesModal.tsx
+++ b/src/components/cookies/PreferencesModal.tsx
@@ -1,6 +1,9 @@
 'use client';
+
 import type { FormEvent } from 'react';
+
 import FocusTrap from './FocusTrap';
+
 import { useConsentStore } from '@/state/useConsentStore';
 
 export default function PreferencesModal() {

--- a/src/components/layout/ConsentScripts.tsx
+++ b/src/components/layout/ConsentScripts.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect } from 'react';
 import Script from 'next/script';
+
 import { useConsentStore } from '@/state/useConsentStore';
 
 export default function ConsentScripts() {

--- a/src/components/map/DeferredMap.tsx
+++ b/src/components/map/DeferredMap.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+
 import { useConsentStore } from '@/state/useConsentStore';
 
 const FALLBACK_SRC =

--- a/src/lib/admin/session.ts
+++ b/src/lib/admin/session.ts
@@ -1,8 +1,9 @@
 // src/lib/admin/session.ts
 import 'server-only';
 
-import { auth } from '@/lib/auth';
 import { isAdminEmail } from './emails';
+
+import { auth } from '@/lib/auth';
 
 export class AdminUnauthorizedError extends Error {
   constructor(message = 'User is not authorized to access admin resources') {

--- a/src/lib/bookingSettings.ts
+++ b/src/lib/bookingSettings.ts
@@ -1,6 +1,7 @@
-import type { BookingType } from '@prisma/client';
-import type { Prisma } from '@prisma/client';
+import type { BookingType, Prisma } from '@prisma/client';
+
 import { prisma } from './prisma';
+
 import type { BookingConfigDTO } from '@/types/bookingConfig';
 
 export type NormalizedBookingSettings = {

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -188,7 +188,9 @@ ${dinnerHtml}
 <p>In cassa comunica:<br/><em>“Prenotazione a nome ${data.name}, ${data.people} persone, codice #${data.id}”.</em></p>
 <p>A presto!<br/>Bar La Soluzione</p>`
   });
-  console.log('[mailer] email cliente sent:', r1.messageId);
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('[mailer] email cliente sent', r1.messageId);
+  }
 
   // Email al bar
   const r2 = await transporter.sendMail({
@@ -205,5 +207,7 @@ Nome: ${data.name}
 Email: ${data.email}
 ${data.phone ? `Telefono: ${data.phone}\n` : ''}${data.notes ? `Note: ${data.notes}\n` : ''}${tierText}${lunchText}${dinnerText}`
   });
-  console.log('[mailer] email admin sent:', r2.messageId);
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn('[mailer] email admin sent', r2.messageId);
+  }
 }

--- a/src/state/useConsentStore.ts
+++ b/src/state/useConsentStore.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+
 import {
   parseConsent,
   serializeConsent,


### PR DESCRIPTION
## Summary
- normalize import grouping across booking flow, consent UI, and supporting libraries to satisfy lint rules
- stabilize Step2 people selection by memoizing the lunch order fallback and fixing effect dependencies
- limit mailer logging to development-friendly warnings to comply with eslint console policy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c939d330832296b2c46cc5a8fb61