### PR TITLE
Add Revolut checkout API integration

### DIFF
--- a/src/app/api/payments/checkout/route.ts
+++ b/src/app/api/payments/checkout/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { createRevolutOrder } from '@/lib/revolut';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: Request) {
+  try {
+    const { orderId } = await req.json().catch(() => ({}));
+    if (!orderId) {
+      return NextResponse.json({ ok: false, error: 'Missing orderId' }, { status: 400 });
+    }
+
+    // Load order & recompute totals from items (if needed). Minimal version:
+    const order = await prisma.order.findUnique({ where: { id: orderId } });
+    if (!order) {
+      return NextResponse.json({ ok: false, error: 'Order not found' }, { status: 404 });
+    }
+
+    const totalCents = order.totalCents ?? 0;
+
+    // Zero-euro flow: no gateway
+    if (totalCents <= 0) {
+      const updated = await prisma.order.update({
+        where: { id: orderId },
+        data: { status: 'paid', paymentRef: 'FREE' },
+      });
+      const redirectUrl = `${process.env.PAY_RETURN_URL}?orderId=${encodeURIComponent(orderId)}&ref=FREE`;
+      return NextResponse.json({ ok: true, data: { mode: 'free', redirectUrl, orderId: updated.id } });
+    }
+
+    // Create Revolut order
+    const description = `Prenotazione #${order.id} - Bar La Soluzione`;
+    const successUrl = `${process.env.PAY_RETURN_URL}?orderId=${encodeURIComponent(order.id)}`;
+    const cancelUrl = `${process.env.PAY_CANCEL_URL}?orderId=${encodeURIComponent(order.id)}`;
+
+    const { paymentRef, publicId } = await createRevolutOrder({
+      amountMinor: totalCents,
+      currency: 'EUR',
+      merchantOrderId: order.id,
+      customer: { email: order.email, name: order.name },
+      description,
+      successUrl,
+      cancelUrl,
+    });
+
+    await prisma.order.update({
+      where: { id: order.id },
+      data: { status: 'pending_payment', paymentRef },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      data: { mode: 'widget', orderId: order.id, paymentRef, publicId },
+    });
+  } catch (err: any) {
+    console.error('[payments][checkout] error', err);
+    return NextResponse.json({ ok: false, error: 'Checkout error' }, { status: 500 });
+  }
+}

--- a/src/app/api/payments/order-status/route.ts
+++ b/src/app/api/payments/order-status/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { retrieveRevolutOrder, isRevolutPaid } from '@/lib/revolut';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const orderId = searchParams.get('orderId');
+    const ref = searchParams.get('ref') || undefined;
+
+    if (!orderId) return NextResponse.json({ ok: false, error: 'Missing orderId' }, { status: 400 });
+
+    const order = await prisma.order.findUnique({ where: { id: orderId } });
+    if (!order) return NextResponse.json({ ok: false, error: 'Order not found' }, { status: 404 });
+
+    // Idempotency shortcut
+    if (order.status === 'paid') {
+      return NextResponse.json({ ok: true, data: { status: 'paid' } });
+    }
+
+    // FREE or API verify
+    if (order.paymentRef === 'FREE') {
+      await prisma.order.update({ where: { id: orderId }, data: { status: 'paid' } });
+      return NextResponse.json({ ok: true, data: { status: 'paid' } });
+    }
+
+    const paymentRef = order.paymentRef || ref;
+    if (!paymentRef) {
+      return NextResponse.json({ ok: true, data: { status: 'pending' } });
+    }
+
+    const remote = await retrieveRevolutOrder(paymentRef);
+    const paid = isRevolutPaid(remote.state);
+
+    if (paid) {
+      await prisma.order.update({ where: { id: orderId }, data: { status: 'paid' } });
+      return NextResponse.json({ ok: true, data: { status: 'paid' } });
+    } else if (remote.state === 'failed' || remote.state === 'cancelled') {
+      await prisma.order.update({ where: { id: orderId }, data: { status: 'failed' } });
+      return NextResponse.json({ ok: true, data: { status: 'failed' } });
+    }
+
+    return NextResponse.json({ ok: true, data: { status: 'pending' } });
+  } catch (err: any) {
+    console.error('[payments][status] error', err);
+    return NextResponse.json({ ok: false, error: 'Status error' }, { status: 500 });
+  }
+}

--- a/src/lib/revolut.ts
+++ b/src/lib/revolut.ts
@@ -1,0 +1,87 @@
+import 'server-only';
+
+type RevolutCreateOrderInput = {
+  amountMinor: number;            // cents
+  currency: 'EUR';
+  merchantOrderId: string;        // local Order.id
+  customer?: { email?: string; name?: string | null };
+  description?: string;
+  successUrl: string;
+  cancelUrl: string;
+};
+
+type RevolutOrderResponse = {
+  id: string;                     // Revolut order/payment id
+  public_id?: string;             // token for client widget (exact field per doc)
+  state?: string;                 // status field (approved, pending, failed...)
+  amount?: number;
+  currency?: string;
+};
+
+const BASE = process.env.REVOLUT_API_BASE!;
+const API_VERSION = process.env.REVOLUT_API_VERSION!;
+const SECRET = process.env.REVOLUT_SECRET_KEY!;
+
+function reqHeaders() {
+  return {
+    'Authorization': `Bearer ${SECRET}`,
+    'Revolut-Api-Version': API_VERSION,
+    'Content-Type': 'application/json',
+  };
+}
+
+export async function revolutFetch<T = any>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: { ...reqHeaders(), ...(init?.headers || {}) },
+    cache: 'no-store',
+    // timeouts handled by platform; keep it simple
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Revolut API ${res.status} on ${path}: ${text}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// NOTE: endpoint path/body shape can differ slightly by API version; keep adapter layer here.
+export async function createRevolutOrder(input: RevolutCreateOrderInput): Promise<{ paymentRef: string; publicId: string }> {
+  // Example body — adapt keys if your API version requires different names.
+  const body = {
+    amount: input.amountMinor,
+    currency: input.currency,
+    merchant_order_id: input.merchantOrderId,
+    description: input.description,
+    customer: {
+      email: input.customer?.email,
+      name: input.customer?.name || undefined,
+    },
+    // success/cancel URLs may live under "checkout" or "payment" options depending on API version
+    success_url: input.successUrl,
+    cancel_url: input.cancelUrl,
+    capture_mode: 'automatic',
+  };
+
+  const resp = await revolutFetch<RevolutOrderResponse>('/orders', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+  const paymentRef = resp.id;
+  const publicId = resp.public_id || '';
+  if (!paymentRef || !publicId) {
+    throw new Error('Missing paymentRef/publicId from Revolut create order response');
+  }
+  return { paymentRef, publicId };
+}
+
+export async function retrieveRevolutOrder(paymentRef: string): Promise<RevolutOrderResponse> {
+  return revolutFetch<RevolutOrderResponse>(`/orders/${encodeURIComponent(paymentRef)}`, {
+    method: 'GET',
+  });
+}
+
+export function isRevolutPaid(state?: string) {
+  // Map Revolut states to "paid"
+  return state === 'approved' || state === 'completed' || state === 'paid' || state === 'settled';
+}


### PR DESCRIPTION
## Summary
- add Revolut API client helper for creating and retrieving orders
- implement checkout API endpoint to create Revolut order or mark free orders as paid
- add order status API endpoint to confirm Revolut payment outcome

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d0e0bffc8322a3ff89242490ad37