### PR TITLE
Add Revolut checkout flows

### DIFF
--- a/src/app/checkout/cancel/page.tsx
+++ b/src/app/checkout/cancel/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function CancelPage() {
+  return (
+    <main className="container py-5">
+      <h1 className="mb-3">Pagamento annullato</h1>
+      <p className="text-muted">Hai annullato il pagamento. Puoi riprovare quando vuoi.</p>
+      <div className="mt-4">
+        <Link href="/prenota" className="btn btn-secondary">
+          Torna al carrello
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ChangeEvent, FormEvent, useMemo, useState } from 'react';
 
 import { ToastProvider, useToast } from '@/components/admin/ui/toast';
+import CheckoutButton from '@/components/cart/CheckoutButton';
 import { useCart } from '@/hooks/useCart';
 import { formatCurrency } from '@/lib/formatCurrency';
 import type { OrderDTO } from '@/types/order';
@@ -144,11 +145,21 @@ function CheckoutContent() {
         className="container"
         style={{ padding: '2rem 1rem', maxWidth: 640, margin: '0 auto', textAlign: 'center' }}
       >
-        <h1 style={{ color: '#b45309' }}>Pagamento non configurato</h1>
-        <p style={{ fontSize: '1.1rem', color: '#0f172a' }}>Pagamento da integrare.</p>
-        <p style={{ color: '#475569' }}>
-          Ti avviseremo appena il gateway di pagamento sarà attivo per completare il tuo ordine.
+        <h1 style={{ color: '#0f172a', marginBottom: '0.5rem' }}>Completa il pagamento</h1>
+        <p style={{ fontSize: '1.05rem', color: '#334155' }}>
+          Ordine <strong>#{order.id}</strong> creato correttamente. Premi il pulsante per aprire il checkout Revolut e
+          finalizzare il pagamento di {formatCurrency(order.totalCents)}.
         </p>
+
+        <div style={{ margin: '2rem auto 0', maxWidth: 320 }}>
+          <CheckoutButton orderId={order.id} />
+        </div>
+
+        <p style={{ marginTop: '1.5rem', color: '#64748b' }}>
+          Una volta completata la transazione verrai reindirizzato alla pagina di conferma. Se chiudi la finestra puoi
+          sempre riprendere il pagamento dal link ricevuto via email.
+        </p>
+
         <div style={{ marginTop: '2rem' }}>
           <Link
             href="/prenota"

--- a/src/app/checkout/return/page.tsx
+++ b/src/app/checkout/return/page.tsx
@@ -1,0 +1,78 @@
+import Link from 'next/link';
+
+type OrderStatus = 'paid' | 'failed' | 'pending';
+
+type StatusResponse = { status: OrderStatus };
+
+async function fetchStatus(orderId: string, ref?: string): Promise<StatusResponse> {
+  const params = new URLSearchParams({ orderId });
+  if (ref) params.set('ref', ref);
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || '';
+  const res = await fetch(`${baseUrl}/api/payments/order-status?${params.toString()}`, {
+    cache: 'no-store',
+  });
+
+  const body = (await res.json().catch(() => null)) as { ok: boolean; data?: StatusResponse; error?: string } | null;
+
+  if (!res.ok || !body?.ok || !body.data) {
+    throw new Error(body?.error || 'Status error');
+  }
+
+  return body.data;
+}
+
+export default async function ReturnPage({ searchParams }: { searchParams: { orderId?: string; ref?: string } }) {
+  const orderId = searchParams?.orderId?.trim();
+  const ref = searchParams?.ref?.trim();
+
+  if (!orderId) {
+    return (
+      <main className="container py-5">
+        <h1 className="mb-3">Esito pagamento</h1>
+        <p className="text-danger">Ordine non valido. Torna al carrello e riprova.</p>
+        <div className="mt-4">
+          <Link href="/prenota" className="btn btn-primary">
+            Torna alle prenotazioni
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  let status: OrderStatus | 'error' = 'pending';
+
+  try {
+    const response = await fetchStatus(orderId, ref);
+    status = response.status;
+  } catch (error) {
+    console.error('[checkout][return] status error', error);
+    status = 'error';
+  }
+
+  return (
+    <main className="container py-5">
+      <h1 className="mb-3">Esito pagamento</h1>
+      {status === 'paid' && (
+        <p className="text-success">
+          Pagamento confermato! Ti abbiamo inviato una conferma via email. Ordine #{orderId}.
+        </p>
+      )}
+      {status === 'failed' && <p className="text-danger">Pagamento non riuscito o annullato.</p>}
+      {status === 'pending' && (
+        <p className="text-muted">
+          Pagamento in elaborazione… ricarica tra qualche secondo oppure controlla l’email per aggiornamenti.
+        </p>
+      )}
+      {status === 'error' && (
+        <p className="text-danger">Impossibile verificare lo stato del pagamento. Riprova più tardi.</p>
+      )}
+
+      <div className="mt-4">
+        <Link href="/prenota" className="btn btn-primary">
+          Torna alle prenotazioni
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/components/cart/CheckoutButton.tsx
+++ b/src/components/cart/CheckoutButton.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+
+declare global {
+  interface Window {
+    RevolutCheckout?: (publicKey: string) => { pay(publicId: string): Promise<void> };
+  }
+}
+
+const PUBLIC_KEY = process.env.NEXT_PUBLIC_REVOLUT_PUBLIC_KEY;
+
+type Props = { orderId: string; disabled?: boolean };
+
+export default function CheckoutButton({ orderId, disabled }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  async function startCheckout() {
+    try {
+      setLoading(true);
+      const res = await fetch('/api/payments/checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ orderId }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | { ok: boolean; data?: { mode: 'free'; redirectUrl: string } | { mode: 'widget'; publicId: string }; error?: string }
+        | null;
+
+      if (!res.ok || !body?.ok || !body.data) {
+        throw new Error(body?.error || 'Checkout error');
+      }
+
+      if (body.data.mode === 'free') {
+        window.location.href = body.data.redirectUrl;
+        return;
+      }
+
+      const publicId = body.data.publicId;
+
+      if (!PUBLIC_KEY) {
+        throw new Error('Revolut public key is not configured');
+      }
+
+      await ensureRevolutScript();
+
+      const revolutCheckout = window.RevolutCheckout;
+      if (typeof revolutCheckout !== 'function') {
+        throw new Error('RevolutCheckout not available');
+      }
+
+      const widget = revolutCheckout(PUBLIC_KEY);
+      if (!widget || typeof widget.pay !== 'function') {
+        throw new Error('Revolut widget not available');
+      }
+
+      await widget.pay(publicId);
+    } catch (error) {
+      console.error('[checkout][client] error', error);
+      alert('Pagamento non avviato. Riprova tra poco.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button className="btn btn-success w-100" onClick={startCheckout} disabled={disabled || loading}>
+      {loading ? 'Avvio pagamento…' : 'Paga con Revolut'}
+    </button>
+  );
+}
+
+function ensureRevolutScript(): Promise<void> {
+  const id = 'revolut-pay-script';
+  if (document.getElementById(id)) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = id;
+    script.src = 'https://merchant.revolut.com/checkout.js';
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Failed to load Revolut script'));
+    document.head.appendChild(script);
+  });
+}


### PR DESCRIPTION
## Summary
- add a client-side Revolut checkout button that starts the API-only widget flow
- guide pending orders to launch the Revolut payment widget with updated copy
- provide dedicated return and cancel result pages for Revolut redirects

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d1fb359083229199b493c5d173e2