### PR TITLE
Fix cart API typing and add client stubs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,10 @@
 // next.config.mjs
 import createMDX from '@next/mdx';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const isProd = process.env.NODE_ENV === 'production';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -11,9 +14,19 @@ const nextConfig = {
   experimental: { mdxRs: true },
 
   // Estensioni di pagina supportate
-  pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
+  pageExtensions: ['tsx', 'ts', 'mdx'],
 
   images: { remotePatterns: [] },
+
+  webpack(config) {
+    config.resolve = config.resolve ?? {};
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      '@mdx-js/react': path.join(__dirname, 'src/lib/mdx-react-stub.tsx'),
+      '@revolut/checkout': path.join(__dirname, 'src/lib/revolut-checkout.ts'),
+    };
+    return config;
+  },
 
   async headers() {
     // In dev lasciamo 'unsafe-eval' per Fast Refresh; in prod lo togliamo.
@@ -47,12 +60,9 @@ const nextConfig = {
   },
 };
 
-// MDX plugin con import provider esplicito
+// MDX plugin base
 const withMDX = createMDX({
   extension: /\.mdx?$/,
-  options: {
-    providerImportSource: '@mdx-js/react',
-  },
 });
 
 export default withMDX(nextConfig);

--- a/src/app/admin/not-authorized/page.tsx
+++ b/src/app/admin/not-authorized/page.tsx
@@ -21,8 +21,8 @@ export default function NotAuthorizedPage() {
       <div style={{ textAlign: 'center', maxWidth: 420, display: 'grid', gap: '1rem' }}>
         <h1 style={{ fontSize: '2rem', margin: 0 }}>Accesso non autorizzato</h1>
         <p style={{ margin: 0, color: '#d1d5db' }}>
-          L'indirizzo email utilizzato non fa parte della lista autorizzata. Se pensi ci sia un
-          errore contatta il responsabile del sito.
+          {"L'indirizzo email utilizzato non fa parte della lista autorizzata. Se pensi ci sia un"}
+          {" errore contatta il responsabile del sito."}
         </p>
         <a
           href="/admin/signin"

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -103,7 +103,7 @@ export default async function AdminDashboardPage() {
           <div style={cardStyle}>
             <h2 style={cardTitleStyle}>Da confermare</h2>
             <p style={countStyle}>{pendingConfirmation}</p>
-            <p style={cardHintStyle}>Richieste in stato "pending"</p>
+            <p style={cardHintStyle}>Richieste in stato &quot;pending&quot;</p>
           </div>
           <div style={cardStyle}>
             <h2 style={cardTitleStyle}>Annullate</h2>

--- a/src/app/admin/signin/page.tsx
+++ b/src/app/admin/signin/page.tsx
@@ -58,7 +58,7 @@ export default function AdminSignInPage({ searchParams }: PageProps) {
               fontSize: '0.95rem'
             }}
           >
-            Questo indirizzo non è autorizzato ad accedere all'area admin.
+            {"Questo indirizzo non è autorizzato ad accedere all'area admin."}
           </div>
         )}
 

--- a/src/components/admin/settings/SettingsForm.tsx
+++ b/src/components/admin/settings/SettingsForm.tsx
@@ -119,9 +119,10 @@ function SettingsFormInner({ settings, allTypes }: Props) {
 
       setAlert(null);
       toast.success('Impostazioni aggiornate');
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('[SettingsForm] update error', error);
-      setAlert({ kind: 'error', message: error?.message ?? 'Impossibile salvare le impostazioni' });
+      const message = error instanceof Error ? error.message : 'Impossibile salvare le impostazioni';
+      setAlert({ kind: 'error', message });
     } finally {
       setSaving(false);
     }
@@ -246,8 +247,8 @@ function SettingsFormInner({ settings, allTypes }: Props) {
           />
         </label>
         <p style={{ margin: 0, color: '#6b7280', fontSize: '0.9rem' }}>
-          Tipologie contrassegnate come "richiede pagamento" mostreranno il bottone di pre-pagamento nel
-          flusso pubblico. L'importo viene usato anche nei messaggi email.
+          Tipologie contrassegnate come &quot;richiede pagamento&quot; mostreranno il bottone di pre-pagamento nel
+          flusso pubblico. L&apos;importo viene usato anche nei messaggi email.
         </p>
       </section>
 

--- a/src/components/cart/CheckoutButton.tsx
+++ b/src/components/cart/CheckoutButton.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import RevolutCheckout from '@revolut/checkout';
+
+import loadRevolutCheckout from '@/lib/revolut-checkout';
 
 export default function CheckoutButton({ orderId, disabled }: { orderId: string; disabled?: boolean }) {
   const [loading, setLoading] = useState(false);
@@ -27,7 +28,7 @@ export default function CheckoutButton({ orderId, disabled }: { orderId: string;
       }
 
       const { token } = data;
-      const instance = await RevolutCheckout(token, 'sandbox');
+      const instance = await loadRevolutCheckout(token, 'sandbox');
 
       instance.payWithPopup({
         onSuccess() {
@@ -40,9 +41,10 @@ export default function CheckoutButton({ orderId, disabled }: { orderId: string;
           window.location.href = `/checkout/cancel?orderId=${encodeURIComponent(orderId)}`;
         },
       });
-    } catch (e: any) {
-      console.error('[checkout][client] error', e);
-      alert(e?.message || 'Pagamento non avviato. Riprova tra poco.');
+    } catch (error: unknown) {
+      console.error('[checkout][client] error', error);
+      const message = error instanceof Error ? error.message : 'Pagamento non avviato. Riprova tra poco.';
+      alert(message);
     } finally {
       setLoading(false);
     }

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,23 +1,84 @@
 // src/lib/cart.ts
 import { prisma } from '@/lib/prisma';
 
-// funzione dummy per avere i tipi reali (non viene mai eseguita)
-function _cartWithItemsType() {
-  return prisma.cart.findUnique({
-    where: { id: '' as string },
-    include: { items: true },
-  });
+export type CartItemEntity = {
+  id: number;
+  cartId: string;
+  productId: number;
+  nameSnapshot: string;
+  priceCentsSnapshot: number;
+  qty: number;
+  imageUrlSnapshot: string | null;
+  meta: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type CartWithItems = {
+  id: string;
+  status: string;
+  totalCents: number;
+  createdAt: Date;
+  updatedAt: Date;
+  items: CartItemEntity[];
+};
+
+function mapCartWithItems(cart: {
+  id: string;
+  status: string;
+  totalCents: number;
+  createdAt: Date;
+  updatedAt: Date;
+  items: Array<{
+    id: number;
+    cartId: string;
+    productId: number;
+    nameSnapshot: string;
+    priceCentsSnapshot: number;
+    qty: number;
+    imageUrlSnapshot: string | null;
+    meta: unknown;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+}): CartWithItems {
+  return {
+    id: cart.id,
+    status: cart.status,
+    totalCents: cart.totalCents,
+    createdAt: cart.createdAt,
+    updatedAt: cart.updatedAt,
+    items: cart.items.map((item) => ({
+      id: item.id,
+      cartId: item.cartId,
+      productId: item.productId,
+      nameSnapshot: item.nameSnapshot,
+      priceCentsSnapshot: item.priceCentsSnapshot,
+      qty: item.qty,
+      imageUrlSnapshot: item.imageUrlSnapshot,
+      meta: item.meta,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    })),
+  };
 }
-export type CartWithItems = NonNullable<
-  Awaited<ReturnType<typeof _cartWithItemsType>>
->;
-type CartItemEntity = CartWithItems['items'][number];
 
 async function findCartWithItems(id: string): Promise<CartWithItems | null> {
-  return prisma.cart.findUnique({
+  const cart = await prisma.cart.findUnique({
     where: { id },
     include: { items: true },
-  }) as Promise<CartWithItems | null>;
+  });
+
+  if (!cart) return null;
+
+  return mapCartWithItems({
+    ...cart,
+    items: cart.items.map((item) => ({
+      ...item,
+      imageUrlSnapshot: item.imageUrlSnapshot ?? null,
+      meta: item.meta as unknown,
+    })),
+  });
 }
 
 export async function getCartById(id: string): Promise<CartWithItems | null> {
@@ -39,17 +100,23 @@ export async function ensureCart(token?: string | null): Promise<CartWithItems> 
     include: { items: true },
   });
 
-  return created as CartWithItems;
+  return mapCartWithItems({
+    ...created,
+    items: created.items.map((item) => ({
+      ...item,
+      imageUrlSnapshot: item.imageUrlSnapshot ?? null,
+      meta: item.meta as unknown,
+    })),
+  });
 }
 
 export async function recalcCartTotal(cartId: string) {
-  type PQ = { priceCentsSnapshot: number; qty: number };
   const items = await prisma.cartItem.findMany({
     where: { cartId },
     select: { priceCentsSnapshot: true, qty: true },
   });
-  const total = items.reduce(
-    (acc: number, it: PQ) => acc + it.priceCentsSnapshot * it.qty,
+  const total = items.reduce<number>(
+    (acc, item) => acc + item.priceCentsSnapshot * item.qty,
     0
   );
   await prisma.cart.update({ where: { id: cartId }, data: { totalCents: total } });
@@ -64,14 +131,17 @@ export function toCartDTO(cart: CartWithItems): CartDTO {
     token: cart.id, // nel tuo dominio token == id
     status: cart.status as CartDTO['status'],
     totalCents: cart.totalCents,
-    items: cart.items.map((it: CartItemEntity) => ({
-      id: it.id,
-      productId: it.productId,
-      nameSnapshot: it.nameSnapshot,
-      priceCentsSnapshot: it.priceCentsSnapshot,
-      qty: it.qty,
-      imageUrlSnapshot: it.imageUrlSnapshot ?? undefined,
-      meta: (it.meta as unknown) ?? undefined,
-    })),
+    items: cart.items.map((it: CartItemEntity) => {
+      const metaValue = it.meta;
+      return {
+        id: it.id,
+        productId: it.productId,
+        nameSnapshot: it.nameSnapshot,
+        priceCentsSnapshot: it.priceCentsSnapshot,
+        qty: it.qty,
+        imageUrlSnapshot: it.imageUrlSnapshot ?? undefined,
+        ...(metaValue == null ? {} : { meta: metaValue }),
+      };
+    }),
   };
 }

--- a/src/lib/mdx-react-stub.tsx
+++ b/src/lib/mdx-react-stub.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, type ComponentType, type PropsWithChildren } from 'react';
+
+type MDXComponents = Record<string, ComponentType<unknown>>;
+
+type MDXProviderProps = PropsWithChildren<{ components?: MDXComponents | ((components: MDXComponents) => MDXComponents) }>;
+
+const MDXComponentsContext = createContext<MDXComponents>({});
+
+function mergeComponents(base: MDXComponents, overrides?: MDXProviderProps['components']): MDXComponents {
+  if (!overrides) return base;
+  if (typeof overrides === 'function') {
+    return overrides(base);
+  }
+  return { ...base, ...overrides };
+}
+
+export function MDXProvider({ components, children }: MDXProviderProps) {
+  const parent = useContext(MDXComponentsContext);
+  const value = mergeComponents(parent, components);
+  return <MDXComponentsContext.Provider value={value}>{children}</MDXComponentsContext.Provider>;
+}
+
+export function useMDXComponents(components?: MDXProviderProps['components']): MDXComponents {
+  const context = useContext(MDXComponentsContext);
+  return mergeComponents(context, components);
+}
+
+export function withMDXComponents<TProps>(Component: ComponentType<TProps>): ComponentType<TProps> {
+  function WithMDXComponents(props: TProps) {
+    return <Component {...props} mdxComponents={useMDXComponents()} />;
+  }
+  WithMDXComponents.displayName = `withMDXComponents(${Component.displayName ?? Component.name ?? 'Component'})`;
+  return WithMDXComponents;
+}
+
+export default { MDXProvider, useMDXComponents, withMDXComponents };

--- a/src/lib/revolut-checkout.ts
+++ b/src/lib/revolut-checkout.ts
@@ -1,0 +1,54 @@
+const REVOLUT_SDK_URL = 'https://checkout.revolut.com/checkout.js';
+
+type RevolutCheckoutInstance = {
+  payWithPopup(options: {
+    onSuccess?: () => void;
+    onError?: () => void;
+    onCancel?: () => void;
+  }): void;
+};
+
+declare global {
+  interface Window {
+    RevolutCheckout?: (token: string, environment: string) => RevolutCheckoutInstance;
+  }
+}
+
+async function loadRevolutSdk(): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  if (typeof window.RevolutCheckout === 'function') {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(`script[src="${REVOLUT_SDK_URL}"]`);
+    if (existing) {
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => reject(new Error('Impossibile caricare Revolut Checkout SDK')), { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = REVOLUT_SDK_URL;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error('Impossibile caricare Revolut Checkout SDK'));
+    document.head.appendChild(script);
+  });
+}
+
+export default async function loadRevolutCheckout(token: string, environment: string): Promise<RevolutCheckoutInstance> {
+  if (typeof window === 'undefined') {
+    throw new Error('Revolut Checkout SDK non disponibile in ambiente server.');
+  }
+
+  await loadRevolutSdk();
+
+  const factory = window.RevolutCheckout;
+  if (typeof factory !== 'function') {
+    throw new Error('Revolut Checkout SDK non disponibile.');
+  }
+
+  return factory(token, environment);
+}


### PR DESCRIPTION
## Summary
- update the cart items API to apply Prisma JSON null handling without implicit anys
- rework cart and order helpers to use explicit DTO-friendly types and totals
- provide MDX and Revolut checkout stubs with Next.js aliases and fix admin copy apostrophes

## Testing
- npx prisma generate *(fails: npm 403 when fetching prisma due to registry restrictions in the execution environment)*
- npx tsc --noEmit *(fails: missing type definition packages because dependencies cannot be installed in the execution environment)*
- npm run build *(fails: `next` binary missing because dependencies cannot be installed in the execution environment)*
- npm run dev *(fails: `next` binary missing because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e50eb7910483228292ed467d2f52be