### PR TITLE
Fix checkout flow and align Order schema

### DIFF
--- a/prisma/migrations/20251008083409_add_notes_to_order/migration.sql
+++ b/prisma/migrations/20251008083409_add_notes_to_order/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `providerRef` on the `Order` table. All the data in the column will be lost.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Order" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "cartId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "phone" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "totalCents" INTEGER NOT NULL,
+    "discountCents" INTEGER,
+    "paymentRef" TEXT,
+    "notes" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Order_cartId_fkey" FOREIGN KEY ("cartId") REFERENCES "Cart" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Order" ("cartId", "createdAt", "discountCents", "email", "id", "name", "notes", "paymentRef", "phone", "status", "totalCents", "updatedAt") SELECT "cartId", "createdAt", "discountCents", "email", "id", "name", "notes", "paymentRef", "phone", "status", "totalCents", "updatedAt" FROM "Order";
+DROP TABLE "Order";
+ALTER TABLE "new_Order" RENAME TO "Order";
+CREATE UNIQUE INDEX "Order_cartId_key" ON "Order"("cartId");
+CREATE INDEX "Order_cartId_status_idx" ON "Order"("cartId", "status");
+CREATE INDEX "Order_paymentRef_idx" ON "Order"("paymentRef");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,13 +155,12 @@ model Order {
   cartId        String   @unique
   email         String
   name          String
-  phone         String
-  notes         String?
+  phone         String?
   status        String   @default("pending")
   totalCents    Int
   discountCents Int?
   paymentRef    String?
-  providerRef   String?  @unique
+  notes         String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 
@@ -169,6 +168,7 @@ model Order {
   bookings Booking[]
 
   @@index([cartId, status])
+  @@index([paymentRef])
 }
 
 model BookingSettings {

--- a/src/app/api/payments/order-status/route.ts
+++ b/src/app/api/payments/order-status/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { NextResponse } from 'next/server';
+import { findOrderByReference, pollOrderStatus } from '@/lib/orders';
 
 export const dynamic = 'force-dynamic';
-
-import { findOrderByReference, pollOrderStatus } from '@/lib/orders';
 
 async function handleStatus(identifier: { orderId?: string | null; ref?: string | null }) {
   let orderId = identifier.orderId?.trim();

--- a/src/app/checkout/schema.ts
+++ b/src/app/checkout/schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const customerSchema = z.object({
+  name: z.string().min(1, 'Nome obbligatorio'),
+  email: z.string().email('Email non valida'),
+  phone: z.string().min(6, 'Telefono obbligatorio'),
+  notes: z.string().max(2000, 'Massimo 2000 caratteri').optional(),
+});
+
+export type CustomerInput = z.infer<typeof customerSchema>;


### PR DESCRIPTION
## Summary
- update the Order model and add a migration to drop `providerRef`, add the `notes` column, and index `paymentRef`
- replace Revolut SDK usage with `sdk.pay()` and enforce the new client checkout flow, including stricter phone validation and cart cleanup on success
- standardise API and server helpers on `paymentRef`, fixing booking creation typing and polling logic

## Testing
- `DATABASE_URL="file:./dev.db" pnpm prisma migrate dev`
- `DATABASE_URL="file:./dev.db" pnpm prisma generate`
- `pnpm exec tsc --noEmit`
- `DATABASE_URL="file:./dev.db" pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_68e621d3d6d883228d1ca06023774f03